### PR TITLE
Fix issue #2 - use of "self" in callables

### DIFF
--- a/Slimdown.php
+++ b/Slimdown.php
@@ -23,8 +23,8 @@
  */
 class Slimdown {
 	public static $rules = array (
-		'/```(.*?)```/s' => 'self::code_parse',                              // code blocks
-		'/\n(#+)(.*)/' => 'self::header',                                   // headers
+		'/```(.*?)```/s' => self::class .'::code_parse',                              // code blocks
+		'/\n(#+)(.*)/' => self::class .'::header',                                   // headers
 		'/\!\[([^\[]+)\]\(([^\)]+)\)/' => '<img src=\'\2\' alt=\'\1\' />',  // images
 		'/\[([^\[]+)\]\(([^\)]+)\)/' => '<a href=\'\2\'>\1</a>',            // links
 		'/(\*\*|__)(.*?)\1/' => '<strong>\2</strong>',                      // bold
@@ -32,11 +32,11 @@ class Slimdown {
 		'/\~\~(.*?)\~\~/' => '<del>\1</del>',                               // del
 		'/\:\"(.*?)\"\:/' => '<q>\1</q>',                                   // quote
 		'/`(.*?)`/' => '<code>\1</code>',                                   // inline code
-		'/\n\*(.*)/' => 'self::ul_list',                                    // ul lists
-		'/\n[0-9]+\.(.*)/' => 'self::ol_list',                              // ol lists
-		'/\n(&gt;|\>)(.*)/' => 'self::blockquote',                          // blockquotes
+		'/\n\*(.*)/' => self::class .'::ul_list',                                    // ul lists
+		'/\n[0-9]+\.(.*)/' => self::class .'::ol_list',                              // ol lists
+		'/\n(&gt;|\>)(.*)/' => self::class .'::blockquote',                          // blockquotes
 		'/\n-{5,}/' => "\n<hr />",                                          // horizontal rule
-		'/\n([^\n]+)\n/' => 'self::para',                                   // add paragraphs
+		'/\n([^\n]+)\n/' => self::class .'::para',                                   // add paragraphs
 		'/<\/ul>\s?<ul>/' => '',                                            // fix extra ul
 		'/<\/ol>\s?<ol>/' => '',                                            // fix extra ol
 		'/<\/blockquote><blockquote>/' => "\n"                              // fix extra blockquote


### PR DESCRIPTION
fixes a deprecation error in PHP 8.2, and is backwards compatible with php 7.4
I did not test on php versions prior to 7.4